### PR TITLE
Make it work with mocks and stubs

### DIFF
--- a/load.bash
+++ b/load.bash
@@ -1,3 +1,8 @@
+# Preserve path at the time this file was sourced
+# This prevents using of user-defined mocks/stubs that modify the PATH
+
+_BATSLIB_PATH="$PATH"
+
 source "$(dirname "${BASH_SOURCE[0]}")/src/output.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/error.bash"
 source "$(dirname "${BASH_SOURCE[0]}")/src/lang.bash"

--- a/src/output.bash
+++ b/src/output.bash
@@ -38,7 +38,7 @@ batslib_err() {
   { if (( $# > 0 )); then
       echo "$@"
     else
-      cat -
+      ( PATH="$_BATSLIB_PATH"; command cat -; )
     fi
   } >&2
 }
@@ -273,7 +273,7 @@ batslib_mark() {
 batslib_decorate() {
   echo
   echo "-- $1 --"
-  cat -
+  ( PATH="$_BATSLIB_PATH"; command cat -; )
   echo '--'
   echo
 }

--- a/test/50-output-10-batslib_err.bats
+++ b/test/50-output-10-batslib_err.bats
@@ -14,3 +14,30 @@ load test_helper
   [ "$status" -eq 0 ]
   [ "$output" == 'm1 m2' ]
 }
+
+@test 'batslib_err() works with modified path' {
+  export PATH="$BATS_TEST_DIRNAME:$PATH"
+  echo 'm1 m2' | {
+    # Verify stub
+    run which cat
+    [ "$status" -eq 0 ]
+    [ "$output" = "$BATS_TEST_DIRNAME/cat" ]
+    # Should still work
+    run batslib_err
+    [ "$status" -eq 0 ]
+    [ "$output" == 'm1 m2' ]
+  }
+}
+
+@test 'batslib_err() works with mock function' {
+  echo 'm1 m2' | {
+    function cat {
+      echo "Mocked cat"
+    }
+    [ "$(cat)" = "Mocked cat" ]
+    # Should still work
+    run batslib_err
+    [ "$status" -eq 0 ]
+    [ "$output" == 'm1 m2' ]
+  }
+}

--- a/test/50-output-19-batslib_decorate.bats
+++ b/test/50-output-19-batslib_decorate.bats
@@ -11,3 +11,36 @@ load test_helper
   [ "${lines[1]}" == 'body' ]
   [ "${lines[2]}" == '--' ]
 }
+
+@test 'batslib_decorate() works with modified path' {
+  export PATH="$BATS_TEST_DIRNAME:$PATH"
+  echo body | {
+    # Verify stub
+    run which cat
+    [ "$status" -eq 0 ]
+    [ "$output" = "$BATS_TEST_DIRNAME/cat" ]
+    # Should still work
+    run batslib_decorate 'title'
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 3 ]
+    [ "${lines[0]}" == '-- title --' ]
+    [ "${lines[1]}" == 'body' ]
+    [ "${lines[2]}" == '--' ]
+  }
+}
+
+@test 'batslib_decorate() works with mock function' {
+  echo body | {
+    function cat {
+      echo "Mocked cat"
+    }
+    [ "$(cat)" = "Mocked cat" ]
+    # Should still work
+    run batslib_decorate 'title'
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 3 ]
+    [ "${lines[0]}" == '-- title --' ]
+    [ "${lines[1]}" == 'body' ]
+    [ "${lines[2]}" == '--' ]
+  }
+}

--- a/test/cat
+++ b/test/cat
@@ -1,0 +1,1 @@
+# Dummy file stubbing a stub/mock


### PR DESCRIPTION
Fixes https://github.com/ztombol/bats-support/issues/8 by saving the PATH and using `command` to ignore functions/aliases

Note: Needed to use a subshell as `PATH="$_BATSLIB_PATH" command cat -` did work for the tests but failed in a real world example and I can't figure out why. Even  `PATH="$_BATSLIB_PATH" command -v cat` outputs the correct path.