### PR TITLE
Add debian package + automatic release changelog

### DIFF
--- a/.github/workflows/make-deb-package.yaml
+++ b/.github/workflows/make-deb-package.yaml
@@ -1,0 +1,94 @@
+name: build-debian-package
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+env:
+  DEBFULLNAME: bats-core-org
+  DEBEMAIL: bats-core@github.com
+jobs:
+  bats-support:
+    name: build bats-support
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract tag name
+        id: tagname
+        shell: bash
+        run: |
+          echo "SUPPORT-TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo ::set-output name=currentag::${GITHUB_REF#refs/tags/}
+
+      - name: Install prerequisites
+        run: sudo apt update; sudo apt install dh-make devscripts -y
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: bats-support-${{ env.SUPPORT-TAG }}
+
+      - name: Dh_make
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: dh_make --createorig -s -y
+
+      - name: Override defaults
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: ls -l; cp pkg/debian/* debian/
+
+      - name: Bats-support - debuild
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: debuild -us -uc
+
+      - name: Bats-support - debinfo
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: dpkg --info ../bats-support_${{ env.SUPPORT-TAG }}*.deb
+
+      - name: Bats-support - install
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: sudo apt install -y ../bats-support_${{ env.SUPPORT-TAG }}*.deb
+
+      - name: Bats-support - make test
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: bats /usr/lib/bats-support/test/
+
+      - name: Bats-support upload deb
+        uses: actions/upload-artifact@v2
+        with:
+          name: results-debs
+          path: ./*_amd64.deb
+
+  make-release:
+    needs: [bats-support]
+    name: release and upload artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract tag name
+        id: tagname
+        shell: bash
+        run: |
+          echo "SUPPORT-TAG=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+          echo ::set-output name=currentag::${GITHUB_REF#refs/tags/}
+
+      - name: Download all workflow run artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: bats-support-${{ env.SUPPORT-TAG }}
+
+      - name: Create changelog
+        working-directory: bats-support-${{ env.SUPPORT-TAG }}
+        run: |
+          sudo apt update; sudo apt install -y dpkg-dev
+          dpkg-parsechangelog -l pkg/debian/changelog --count 0 \
+            --show-field Changes|grep -v bats-support > verchangelog
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          body_path: bats-support-${{ env.SUPPORT-TAG }}/verchangelog
+          body: "Bats-support version ${{ env.SUPPORT-TAG }}"
+          files: |
+            results-debs/bats-*.deb

--- a/pkg/debian/changelog
+++ b/pkg/debian/changelog
@@ -1,0 +1,5 @@
+bats-support (0.3.0-1) unstable; urgency=medium
+
+  * Initial deb release
+
+ -- Bats-core-org <bats-core@github.com>  Sat, 27 Nov 2021 16:14:32 +0100

--- a/pkg/debian/control
+++ b/pkg/debian/control
@@ -1,0 +1,14 @@
+Source: bats-support
+Section: shells
+Priority: optional
+Maintainer: Bats-core-org <bats-core@github.com>
+Build-Depends: debhelper-compat (= 12)
+Standards-Version: 4.4.1
+Homepage: https://github.com/bats-core/bats-support
+#Vcs-Browser: https://salsa.debian.org/debian/bats-support-0.3.0
+#Vcs-Git: https://salsa.debian.org/debian/bats-support-0.3.0.git
+
+Package: bats-support
+Architecture: any
+Depends: ${shlibs:Depends}, ${misc:Depends}, bash, bats
+Description:  Supporting library for Bats test helpers

--- a/pkg/debian/install
+++ b/pkg/debian/install
@@ -1,0 +1,4 @@
+src/* usr/lib/bats-support/src/
+load.bash usr/lib/bats-support/
+LICENSE usr/lib/bats-support/
+test usr/lib/bats-support/

--- a/pkg/debian/watch
+++ b/pkg/debian/watch
@@ -1,0 +1,2 @@
+version=0.3.0
+https://github.com/bats-core/bats-support/archive/refs/tags/v0.3.0.tar.gz


### PR DESCRIPTION
* add debian base deb files
* add ci to build bats-support debian package
* info, install and test the package
* automatic release on new tag with deb package artifact attached
* automatic changelog on new release 

If you are interested I can create the same PR with bats file, detik and assert (and rpm version as well)