### PR TITLE
add distro packaging installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -e
+
+BATS_ROOT="${0%/*}"
+PREFIX="${1%/}"
+LIBDIR="${2:-lib}"
+
+if [[ -z "$PREFIX" ]]; then
+  printf '%s\n' \
+    "usage: $0 <prefix> [base_libdir]" \
+    "  e.g. $0 /usr/local" \
+    "       $0 /usr/local lib64" >&2
+  exit 1
+fi
+
+BATS_LIBDIR=$PREFIX/$LIBDIR/bats/bats-support
+
+install -d -m 755 "$BATS_LIBDIR/src"
+install -m 755 "$BATS_ROOT/load.bash" "$BATS_LIBDIR"
+install -m 755 "$BATS_ROOT/src/"* "$BATS_LIBDIR/src"
+
+echo "Installed Bats Support to $BATS_LIBDIR"


### PR DESCRIPTION
Copy the arguments from the bats-core install.sh so that bats libraries can be packaged in the same manner as bats-core.