### PR TITLE
Create GHA job to sync master with main

### DIFF
--- a/.github/workflows/sync-default-branch.yml
+++ b/.github/workflows/sync-default-branch.yml
@@ -1,0 +1,25 @@
+name: Sync Default Branch
+on:
+  push: { branches: main }
+  workflow_dispatch:
+permissions: {}
+
+jobs:
+  sync-default-branch:
+    if: github.ref_name == github.event.repository.default_branch
+    permissions: {contents: write}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      with: {egress-policy: audit}
+    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+    - run: git push --force origin HEAD:refs/heads/master
+
+# One-time commands for users to switch-over:
+#
+# ```console
+# git branch -m master main
+# git fetch origin
+# git branch -u origin/main main
+# git remote set-head origin -a
+# ```


### PR DESCRIPTION
Supports a transition period where the default branch is renamed to `main`, but all changes are reflected on master as well such that folks who have installed bats-support by using master will continue to receive updates for some time.

## approach

This repo is still using the old `master` branch name as the default branch. I propose we rename to `main`.

The impact to contributors is minimal as we can all handle the rename tasks ourselves. However, because git is not just the tool for development, but also for _distribution_, this change potentially impacts users, not just contributors.

A process I have used successfully on other repos (virtually all [nodenv](https://github.com/nodenv/nodenv/blob/main/.github/workflows/sync-default-branch.yml) repos) to facilitate the master -> main rename:

1. create a "sync" job that force updates the master branch whenever main is modified
  - note that the job will be inert until the main branch exists
2. rename master to main on github
3. manual steps for contributors to change their local dev environment

At this point `main` is the official default branch and all work uses `main`. However, the `master` branch is preserved (as any normal branch). Any time `main` is modified, the job is triggered and force pushes to `master` to keep it in sync with `main`. Thus any users who have their bats testing environment set up by cloning from master will continue to get the latest code. But since `main` is then the new default branch, any clones that do not explicitly reference `master`, will get `main` as their default branch. So over time, references to master will gradually diminish. Eventually the sync job (and master branch) can just be deleted with drastically fewer (if any) users impacted.


