### PR TITLE
add shebang to 'cat' test stub for Windows runners

### DIFF
--- a/test/cat
+++ b/test/cat
@@ -1,1 +1,3 @@
-# Dummy file stubbing a stub/mock
+#!/bin/sh
+# Stub cat used by "modified path" tests.
+# On Windows, a shebang is required so the runner knows how to execute this file.


### PR DESCRIPTION
## Reason

Running this repo's tests on a Windows runner fails unless the `cat` stub has a shebang.

This relates to [PR 15](https://github.com/bats-core/.github/pull/15) in `bats-core/.github`, which adds `windows-latest` to the test OS matrix.

This repo uses the test workflow from `bats-core/.github`. In my forks, the tests for this repo failed on Windows until the shebang was added to the `cat` stub.